### PR TITLE
ci(semantic-release): added release rules to the commit-analyzer plugin

### DIFF
--- a/.github/actions/semantic-release/action.yml
+++ b/.github/actions/semantic-release/action.yml
@@ -101,7 +101,13 @@ runs:
         cat << EOF > .releaserc
         {
           "plugins": [
-            "@semantic-release/commit-analyzer",
+            "@semantic-release/commit-analyzer", {
+              "releaseRules": [
+                {"type": "perf", "release": "patch"},
+                {"type": "refactor", "release": "patch"},
+                {"type": "revert", "release": "patch"}
+              ] 
+            },
             "@semantic-release/release-notes-generator",
             $CHANGELOG_PLUGIN
             $NPM_PLUGIN


### PR DESCRIPTION
https://github.com/semantic-release/commit-analyzer?tab=readme-ov-file#releaserules

> If you define custom release rules the [default rules](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js) will be used if nothing matched.