### PR TITLE
ci: use npm ci optionally

### DIFF
--- a/.github/actions/npm-install-build/action.yml
+++ b/.github/actions/npm-install-build/action.yml
@@ -36,6 +36,8 @@ runs:
         ref: ${{ inputs.ref }}
 
     - uses: cloudbeds/workflows/.github/actions/npm-install@main
+      with:
+        useNpmCI: false
 
     - name: Build
       shell: bash

--- a/.github/actions/npm-install-lint/action.yml
+++ b/.github/actions/npm-install-lint/action.yml
@@ -21,6 +21,8 @@ runs:
         ref: ${{ inputs.ref }}
 
     - uses: cloudbeds/workflows/.github/actions/npm-install@main
+      with:
+        useNpmCI: false
 
     - name: Lint
       shell: bash

--- a/.github/actions/npm-install-test/action.yml
+++ b/.github/actions/npm-install-test/action.yml
@@ -29,6 +29,8 @@ runs:
         ref: ${{ inputs.ref }}
 
     - uses: cloudbeds/workflows/.github/actions/npm-install@main
+      with:
+        useNpmCI: false
 
     - name: Test
       shell: bash

--- a/.github/actions/npm-install/action.yml
+++ b/.github/actions/npm-install/action.yml
@@ -1,6 +1,12 @@
 name: Install NPM packages
 description: Adds NPM token and install node modules
 
+inputs:
+  useNpmCI:
+    description: Use npm ci instead of npm install
+    default: 'true'
+    required: false
+
 runs:
   using: composite
   steps:
@@ -17,12 +23,13 @@ runs:
       uses: actions/setup-node@v4
       with:
         cache: npm
+        node-version: 20.x
 
     - name: Add NPM token to .npmrc
       shell: bash
       run:
-        if [[ -n $NPM_TOKEN && ! -f .npmrc ]];
-          then echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc;
+        if [[ -n $NPM_TOKEN && ! -f .npmrc ]]; then
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc;
         fi
 
     - name: Install dependencies
@@ -30,7 +37,11 @@ runs:
       run: |
         export HUSKY=0
         npm config set audit=false fund=false
-        npm ci
+        if [[ '${{ inputs.useNpmCI }}' == 'true' ]]; then 
+          npm ci
+        else
+          npm install
+        fi
 
     - name: NPM cache push
       uses: actions/cache/save@v4

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -60,6 +60,17 @@ on:
         value: ${{ jobs.build.outputs.appVersion }}
 
 jobs:
+  install:
+    name: Install
+    if: inputs.buildOnly != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Install with npm ci
+        uses: cloudbeds/workflows/.github/actions/npm-install@main
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   lint:
     name: Lint
     if: inputs.buildOnly != 'true'


### PR DESCRIPTION
To leverage `node_modules` cache we are switching the way packages are installed from `npm ci` to `npm install`

`npm ci` does not use the cache so we lose about 20 seconds in every job (_Build, Lint, Test_)

Instead, a new _Install_ job was added to check if `package.json` abides to the dependencies in `package-lock.json`