### PR TITLE
ci: added nvmrc file support

### DIFF
--- a/.github/actions/npm-install/action.yml
+++ b/.github/actions/npm-install/action.yml
@@ -19,11 +19,19 @@ runs:
           node_modules
         key: v1-npm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
 
+    - name: Get node.js version from .nvmrc
+      shell: bash
+      run: |
+        if [[ -f .nvmrc ]]; then
+          echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
+        fi
+
     - name: Initialize npm cache for global packages
       # https://github.com/actions/setup-node
       uses: actions/setup-node@v4
       with:
         cache: npm
+        node-version: ${{ env.NODE_VERSION || '20' }}
 
     - name: Add NPM token to .npmrc
       shell: bash


### PR DESCRIPTION
Added support for `.nvmrc`

Reason: Jest 26 in mfd-core fails with Node.js 20