### PR TITLE
ci: added extra plugins option for semantic release

### DIFF
--- a/.github/actions/npm-install/action.yml
+++ b/.github/actions/npm-install/action.yml
@@ -26,11 +26,11 @@ runs:
           echo "NODE_VERSION=$(cat .nvmrc)" >> $GITHUB_ENV
         fi
 
-    - name: Initialize npm cache for global packages
-      uses: actions/setup-node@v4
-      with:
-        cache: npm
-        node-version: ${{ env.NODE_VERSION || '20' }}
+#    - name: Initialize npm cache for global packages
+#      uses: actions/setup-node@v4
+#      with:
+#        cache: npm
+#        node-version: ${{ env.NODE_VERSION || '20' }}
 
     - name: Add NPM token to .npmrc
       shell: bash

--- a/.github/actions/semantic-release/action.yml
+++ b/.github/actions/semantic-release/action.yml
@@ -26,6 +26,9 @@ inputs:
     description: The branch, tag or SHA to checkout. Defaults to the SHA for the event that triggered the workflow.
     default: ''
     required: false
+  extraPlugins:
+    description: Additional array of plugins to be added to the .releaserc file in JSON format
+    required: false
   GITHUB_TOKEN:
     description: Secret Cloudbeds Github token with write permission
     required: true
@@ -85,41 +88,51 @@ runs:
         echo ""
 
     - name: Create config file for Semantic Release
-      shell: bash
-      run: |
-        echo ""
-        if [[ '${{inputs.withoutChangelog}}' != 'true' ]]; then
-          CHANGELOG_PLUGIN='"@semantic-release/changelog",'
-        fi
-        if [[ '${{inputs.withoutNpmPlugin}}' != 'true' ]]; then
-          NPM_PLUGIN='"@semantic-release/npm", {
-            "npmPublish": ${{inputs.publishToNpm == 'true'}},
-          },'
-        fi
-
-        cat << EOF > .releaserc
-        {
-          "plugins": [
-            ["@semantic-release/commit-analyzer", {
-              "releaseRules": [
-                {"type": "perf", "release": "patch"},
-                {"type": "refactor", "release": "patch"},
-                {"type": "revert", "release": "patch"}
-              ] 
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const inputs = ${{ toJSON(inputs) }};
+          
+          const plugins = [
+            ['@semantic-release/commit-analyzer', {
+              releaseRules: [
+                { type: 'perf', release: 'patch' },
+                { type: 'refactor', release: 'patch' },
+                { type: 'revert', release: 'patch' }
+              ]
             }],
-            "@semantic-release/release-notes-generator",
-            $CHANGELOG_PLUGIN
-            $NPM_PLUGIN
-            "@semantic-release/github",
-            "@semantic-release/git"
-          ]
-        }
-        EOF
-        
-        echo "::group::📂 Contents of .releaserc"
-        cat .releaserc
-        echo "::endgroup::"
-        echo ""
+            '@semantic-release/release-notes-generator',
+          ];
+
+          if (inputs.withoutChangelog !== 'true') {
+            plugins.push('@semantic-release/changelog');
+          }
+
+          if (inputs.withoutNpmPlugin !== 'true') {
+            plugins.push([
+              '@semantic-release/npm',
+              { npmPublish: inputs.publishToNpm === 'true' },
+            ]);
+          }
+
+          plugins.push('@semantic-release/github');
+          plugins.push('@semantic-release/git');
+          
+          const extraPlugins = JSON.parse(inputs.extraPlugins || '[]');
+          
+          if (extraPlugins.length) {
+            extraPlugins.forEach(plugin => plugins.push(plugin));
+          }
+          
+          fs.writeFileSync('.releaserc', JSON.stringify({ plugins }, null, 2));
+          
+          const extraPluginNames = extraPlugins.map(plugin => Array.isArray(plugin) ? plugin[0] : plugin).join(' ');
+          core.exportVariable('EXTRA_PLUGINS', extraPluginNames);
+          
+          console.log('::group::📂 Contents of .releaserc:');
+          console.log(fs.readFileSync('.releaserc'));
+          console.log('::endgroup::');
 
     - name: Semantic Release
       uses: cycjimmy/semantic-release-action@v4
@@ -133,6 +146,7 @@ runs:
         extra_plugins: |
           @semantic-release/changelog
           @semantic-release/git
+          ${{ env.EXTRA_PLUGINS }}
       env:
         GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
         NPM_TOKEN: ${{ inputs.NPM_TOKEN }}


### PR DESCRIPTION
In projects that need extra processing (e.g. using `@semantic-release/exec` or [plugins](https://semantic-release.gitbook.io/semantic-release/extending/plugins-list#community-plugins) like [semantic-release-chrome](https://github.com/GabeDuarteM/semantic-release-chrome)) we need a way to pass those extra plugins via input