### PR TITLE
ci: test retries

### DIFF
--- a/.github/actions/npm-install-test/action.yml
+++ b/.github/actions/npm-install-test/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: The branch, tag or SHA to checkout. Defaults to the SHA for the event that triggered the workflow.
     required: false
     default: ''
+  retries:
+    description: Number of additional attempts to retry the test step on failure
+    required: false
+    default: '0'
 
 outputs:
   hasCoverageReport:
@@ -43,12 +47,36 @@ runs:
         # deprecated
         npm run downloadTypes --if-present
 
-        if [[ $(jq '.scripts["test:coverage:ci"]' < package.json;) != null && "${{ inputs.withoutCoverage }}" != 'true' ]]; then
-          npm run test:coverage:ci
-          echo "INCLUDE_COVERAGE_REPORT=true" >> $GITHUB_OUTPUT
-        elif [[ $(jq '.scripts["test:coverage"]' < package.json;) != null && "${{ inputs.withoutCoverage }}" != 'true' ]]; then
-          npm run test:coverage
-          echo "INCLUDE_COVERAGE_REPORT=true" >> $GITHUB_OUTPUT
-        else
-          npm run test --if-present
+        maxRuns=$(( ${{ inputs.retries }} + 1 ))
+        runCounter=1
+
+        until [ $runCounter -gt $maxRuns ]
+        do
+          if [ $runCounter -gt 1 ]; then
+            echo "::group::Retry run $runCounter of $maxRuns"
+          fi
+        
+          if [[ $(jq '.scripts["test:coverage:ci"]' < package.json;) != null && "${{ inputs.withoutCoverage }}" != 'true' ]]; then
+            npm run test:coverage:ci && break
+            echo "INCLUDE_COVERAGE_REPORT=true" >> $GITHUB_OUTPUT
+          elif [[ $(jq '.scripts["test:coverage"]' < package.json;) != null && "${{ inputs.withoutCoverage }}" != 'true' ]]; then
+            npm run test:coverage && break
+            echo "INCLUDE_COVERAGE_REPORT=true" >> $GITHUB_OUTPUT
+          else
+            npm run test --if-present && break
+          fi
+
+          echo "Test suite failed. Retrying..."
+          runCounter=$((runCounter + 1))
+
+          if [ $runCounter -gt 1 ]; then
+            echo "::endgroup::"
+          fi
+        done
+
+        if [ $runCounter -gt $maxRuns ]; then
+          if [ $runCounter -gt 1 ]; then
+            echo "::warning::Test suite failed after $maxRuns attempts"
+          fi
+          exit 1
         fi

--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -43,6 +43,11 @@ on:
         required: false
         default: coverage
         type: string
+      testRetries:
+        description: Number of additional attempts to retry the test job on failure
+        required: false
+        type: number
+        default: 0
       writeBuildInfo:
         description: Whether to write build info to a file
         required: false
@@ -101,6 +106,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           envVars: ${{ inputs.envVars }}
+          retries: ${{ inputs.testRetries }}
           ref: ${{ inputs.ref }}
 
       - name: Find Current Pull Request


### PR DESCRIPTION
Some test suites like the ChannelSetup in mfd-core grew so significantly that the pipeline started to fail occasionally with:

```
Error: Process completed with exit code 130.
```

As a temporary quick and dirty fix, addressing it with by adding a retry option