### PR TITLE
chore(ci): bump jest-coverage-report-action to 2.3.1

### DIFF
--- a/.github/workflows/npm-build-test.yml
+++ b/.github/workflows/npm-build-test.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Report Test Coverage
         if: steps.test.outputs.hasCoverageReport == 'true'
-        uses: ArtiomTr/jest-coverage-report-action@v2.2.4
+        uses: ArtiomTr/jest-coverage-report-action@v2.3.1
         with:
           prnumber: ${{ steps.findPr.outputs.number }}
           annotations: ${{ inputs.testCoverageAnnotations }}

--- a/.github/workflows/npm-lint-test.yml
+++ b/.github/workflows/npm-lint-test.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Report Test Coverage
         if: env.INCLUDE_COVERAGE_REPORT == 'true'
-        uses: ArtiomTr/jest-coverage-report-action@v2.2.4
+        uses: ArtiomTr/jest-coverage-report-action@v2.3.1
         with:
           prnumber: ${{ steps.findPr.outputs.number }}
           annotations: coverage

--- a/.github/workflows/npm-sequential-build-test.yml
+++ b/.github/workflows/npm-sequential-build-test.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Report Test Coverage
         if: env.INCLUDE_COVERAGE_REPORT == 'true'
-        uses: ArtiomTr/jest-coverage-report-action@v2.2.4
+        uses: ArtiomTr/jest-coverage-report-action@v2.3.1
         with:
           prnumber: ${{ steps.findPr.outputs.number }}
           annotations: ${{ inputs.testCoverageAnnotations }}


### PR DESCRIPTION
When there are more than 300 files changes our Test Pipelines fail.

See: https://github.com/cloudbeds/mfd-amplify/actions/runs/12319789989/job/34387757458?pr=647

This was fixed in the version `2.3.1` of `ArtiomTr/jest-coverage-report-action`

See: https://github.com/ArtiomTr/jest-coverage-report-action/pull/431

Therefore, I decided to bump the action version, so that our pipelines stop failing. 

Additionally, no big changes were found in the action release notes, which is why I think it is safe to upgrade.

See: https://github.com/ArtiomTr/jest-coverage-report-action/releases